### PR TITLE
=BG= webstorm executable paths on linux

### DIFF
--- a/ide/webstorm/webstorm.js
+++ b/ide/webstorm/webstorm.js
@@ -50,8 +50,17 @@ WebStorm.prototype.executable = function () {
     return '/Applications/WebStorm.app/Contents/MacOS/webide';
 
   } else if (platform.isUnix()) {
-    return path.join('opt/webstorm/bin/webstorm.sh');
-
+    var selectedExecPath = null;
+    [
+      '/usr/local/bin/wstorm',
+      '/opt/webstorm/bin/webstorm.sh'
+    ].forEach(function(execPath) {
+      if (io.existsFileSync(execPath)) {
+        selectedExecPath = execPath;
+      }
+    });
+    return selectedExecPath;
+    
   } else {
     return null;
   }


### PR DESCRIPTION
- original path `/opt/..` instead of `opt/..` (absolute path)
- check a new location too, default in Linux installations: `/usr/local/bin/wstorm`
