### PR TITLE
=BG= quotes are problematic in Linux

### DIFF
--- a/ide/IDE.js
+++ b/ide/IDE.js
@@ -21,7 +21,9 @@ function IDE(name) {
 IDE.prototype = {
   constructor       : IDE,
   open              : function (location) {
-    location = '"' + location + '"';
+    if (platform.isWindows()) {
+      location = '"' + location + '"';
+    }
     console.log('opening,', this.executable(), ' at ', location);
     childProcess.spawn(this.executable(), [location], {detached: true});
   },


### PR DESCRIPTION
- `child_process.spawn()` doesn't play nice with arguments that are quoted
- Not sure about whether quotes are needed in windows, so leaving them in for now - please test/ fix accordingly